### PR TITLE
Errors When Linking Other Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ dune build
 to test
 
 ```
-$ dune exec -- coqtop -R MyPlugin _build/default/theories
+$ dune exec -- coqtop -R _build/default/theories MyPlugin
 ```
 
 ## Composing with Coq

--- a/my-plugin.opam
+++ b/my-plugin.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml"         { >= "4.07.1"           }
   "coq"           { >= "8.9.0" & < "8.10" }
   "dune"          { build & >= "1.9.0"    }
+  "z3"
 ]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]

--- a/src/ce_api.ml
+++ b/src/ce_api.ml
@@ -14,3 +14,8 @@ let printHello : unit PV.tactic =
   let open PV.Notations in
   msg_in_tactic "hello" >>= fun () ->
   Tacticals.New.tclIDTAC
+
+let smt : unit PV.tactic = 
+  let open PV.Notations in
+  msg_in_tactic Z3.Version.to_string >>= fun () ->
+  Tacticals.New.tclIDTAC

--- a/src/ce_syntax.ml4
+++ b/src/ce_syntax.ml4
@@ -7,6 +7,10 @@ TACTIC EXTEND Hello
 | [ "hello" ] -> [ Ce_api.printHello ]
 END
 
+TACTIC EXTEND Smt
+| [ "smt" ] -> [ Ce_api.smt ]
+END
+
 VERNAC COMMAND EXTEND CallToC CLASSIFIED AS QUERY
 | [ "CallC" ] -> [ let i = Ce_api.callC () in Feedback.msg_warning Pp.(int i) ]
 END

--- a/src/dune
+++ b/src/dune
@@ -7,6 +7,7 @@
  (libraries
    coq.vernac                      ; needed for vernac extend
    coq.plugins.ltac                ; needed only for tactic extend
+   z3
 ))
 
 (rule


### PR DESCRIPTION
Hello Emilio,

Could you have a look at this when you have time? Many thanks.

I'm trying to write a tactic that calls Z3. Right now it just prints the Z3 version (similar to the hello tactic).  But I have the following error when running `dune build`. 

It looks like there is something wrong in the linking. The error also occurs when I try to replace Z3 with other 3rd-party libraries such as jane street core. Maybe this is related to the "Caveats" in the README? 

From what I read in [Coq's issue](https://github.com/coq/coq/issues/7698), there isn't a good way to link 3rd-party libraries in a Coq plugin? If that's the case, I guess I can use Z3's command line tool rather than the OCaml binding. But it would be good if there is a workaround.
 


OCaml version: 4.07.1+flambda, Coq version: 8.9

```
        coqc theories/Test.vo (exit 1)
(cd _build/default/theories && /Users/yangky/.opam/4.07.1+flambda/bin/coqc -I ../src -R . MyPlugin Test.v)
File "./Test.v", line 1, characters 0-35:
Error:
while loading
/Users/yangky/Desktop/Research/Project-A/coq-plugin-template/_build/default/src/example_plugin.cmxs:
error loading shared library: dlopen(/Users/yangky/Desktop/Research/Project-A/coq-plugin-template/_build/default/src/example_plugin.cmxs, 10): Symbol not found: _camlZ3__Pmakeblock_16718
  Referenced from: /Users/yangky/Desktop/Research/Project-A/coq-plugin-template/_build/default/src/example_plugin.cmxs
  Expected in: flat namespace
 in /Users/yangky/Desktop/Research/Project-A/coq-plugin-template/_build/default/src/example_plugin.cmxs
```